### PR TITLE
Add tree traversals to tree.py

### DIFF
--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -515,7 +515,39 @@ class SparseTree(object):
             if self.is_internal(v):
                 stack.extend(reversed(self.get_children(v)))
             yield v
+    
+    def _postorder_traversal(self, u):
+        stack = [u]
+        k = NULL_NODE
+        while stack:
+            v = stack[-1]
+            if self.is_internal(v) and v != k:
+                stack.extend(reversed(self.get_children(v)))
+            else:
+                k = self.get_parent(v)
+                yield stack.pop()
 
+    def _inorder_traversal(self, u):
+        stack = [u]
+        k, j = NULL_NODE, NULL_NODE
+        while stack:
+            v = stack.pop()
+            if self.is_internal(v) and v != k and v != j:
+                children = self.get_children(v)
+                j = stack[-1] if stack else NULL_NODE
+                stack.extend([children[1], v, children[0]])
+            else:
+                k = self.get_parent(v)
+                yield v
+    
+    def _levelorder_traversal(self, u):
+        queue = collections.deque([u])
+        while queue:
+            v = queue.popleft()
+            if self.is_internal(v):
+                queue.extend(self.get_children(v))
+            yield v
+    
     def nodes(self, root=None, order="preorder"):
         """
         Returns an iterator over the nodes in this tree. If the root parameter
@@ -524,13 +556,19 @@ class SparseTree(object):
         is provided, iterate over the nodes in required tree traversal order.
 
         :param int root: The root of the subtree we are traversing.
-        :param str order: The traversal ordering. Currently only 'preorder'
-            is supported.
+        :param str order: The traversal ordering. Currently 'preorder', 'inorder',
+            'postorder' and 'levelorder' ('breadthfirst') are supported.
         :rtype: iterator
         """
         u = self.get_root() if root is None else root
         if order == "preorder":
             return self._preorder_traversal(u)
+        elif order == "postorder":
+            return self._postorder_traversal(u)
+        elif order == "inorder":
+            return self._inorder_traversal(u)
+        elif order == "levelorder" or order == "breadthfirst":
+            return self._levelorder_traversal(u)
         else:
             raise ValueError(
                 "Traversal ordering '{}' not supported".format(order))


### PR DESCRIPTION
Added 'inorder', 'postorder' and 'levelorder' (='breadthfirst') tree traversals to tree.py. Not sure if these are the most efficient (or most Pythonic) non-recursive algorithms, but they should work. 

Example output:

`{0: 12, 1: 14, 2: 11, 3: 15, 4: 13, 5: 12, 6: 11, 7: 13, 8: 10, 9: 10, 10: 14, 11: 15, 12: 16, 13: 18, 14: 16, 15: 17, 16: 17, 17: 18, 18: -1} 

preorder: [18, 13, 4, 7, 17, 15, 3, 11, 2, 6, 16, 12, 0, 5, 14, 1, 10, 8, 9]
postorder: [4, 7, 13, 3, 2, 6, 11, 15, 0, 5, 12, 1, 8, 9, 10, 14, 16, 17, 18]
inorder: [4, 13, 7, 18, 3, 15, 2, 11, 6, 17, 0, 12, 5, 16, 1, 14, 8, 10, 9]
levelorder: [18, 13, 17, 4, 7, 15, 16, 3, 11, 12, 14, 2, 6, 0, 5, 1, 10, 8, 9]`

![image](https://cloud.githubusercontent.com/assets/11942736/19930827/0a3e6c24-a102-11e6-841a-46a5c4b598a3.png)
